### PR TITLE
Populate category with all attributes

### DIFF
--- a/Model/Wrapper/Category.php
+++ b/Model/Wrapper/Category.php
@@ -39,10 +39,10 @@ class Category extends SourceWrapper
     protected function loadSource()
     {
         if ($this->data instanceof \Magento\Catalog\Api\Data\CategoryInterface) {
-            return $this->data;
+
+            return $this->categoryRespository
+                        ->get($this->data['entity_id']);
         }
-        return $this->categoryRespository
-            ->get($this->data['id']);
     }
 
     /**


### PR DESCRIPTION
It is currently not possible to create shipping rules based on the category name, because the category is not populated with all necessary data. See [here](https://github.com/owebia/magento2-module-advanced-shipping/issues/84#issuecomment-688755267).

This pull request populates the category with all data.