### PR TITLE
Added php 8.1 version to the composer.json and bumped version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "owebia/magento2-module-shared-php-config",
     "description": "N/A",
     "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0",
+        "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0|~8.1.0",
         "magento/framework": "^100.0|^101.0|^102.0|^103.0",
         "magento/module-backend": "^100.0|^101.0|^102.0",
         "magento/module-catalog": "^100.0|^101.0|^102.0|^103.0|^104.0",
@@ -17,7 +17,7 @@
         "nikic/php-parser": "^3.1.0|^4.0.0"
     },
     "type": "magento2-module",
-    "version": "3.0.5",
+    "version": "3.0.6",
     "license": [
         "proprietary"
     ],


### PR DESCRIPTION
Adding PHP 8.1 to the composer file in order to support Magento 2.4.4 and PHP 8.1

I ran a PHPCompatibility test with PHPCS for 8.1 and nothing showed up.